### PR TITLE
Incubator Control service connection to local REEF server

### DIFF
--- a/frontend/components/IncubatorControl.jsx
+++ b/frontend/components/IncubatorControl.jsx
@@ -150,7 +150,7 @@ const IncubatorControl = ({ incubatorControlService, appendLog }) => {
 };
 
 IncubatorControl.propTypes = {
-  incubatorControlService: PropTypes.object.isRequired,
+  incubatorControlService: PropTypes.object,
   appendLog: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
Since Kubernetes can directly access reef.dyn.scilifelab.se, we can simply use the reef server’s local address.