### PR TITLE
Browse time lapse data

### DIFF
--- a/agent_lens/register_frontend_service.py
+++ b/agent_lens/register_frontend_service.py
@@ -9,6 +9,11 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from agent_lens.artifact_manager import TileManager, AgentLensArtifactManager
 from hypha_rpc import connect_to_server
+import base64
+import io
+import httpx
+import numpy as np
+from PIL import Image
 
 ARTIFACT_ALIAS = "microscopy-tiles-complete"
 DEFAULT_CHANNEL = "BF_LED_matrix_full"
@@ -182,6 +187,171 @@ def get_frontend_api():
             print(traceback.format_exc())
             from fastapi.responses import JSONResponse
             return JSONResponse(content={"error": str(e)}, status_code=404)
+
+    @app.get("/setup-image-map")
+    async def setup_image_map(dataset_name: str):
+        """
+        Endpoint to setup the image map access for a specific dataset.
+        Checks if the corresponding dataset exists in the image-map gallery.
+
+        Args:
+            dataset_name (str): The name of the current dataset (e.g., "20250410-treatment").
+
+        Returns:
+            dict: A dictionary containing success status and message.
+        """
+        print(f"Setting up image map for dataset: {dataset_name}")
+        # Ensure the artifact manager is connected
+        if artifact_manager_instance.server is None:
+            _, artifact_manager_instance._svc = await get_artifact_manager()
+        
+        try:
+            # Target gallery for image maps
+            gallery_id = "reef-imaging/image-map-of-u2os-fucci-drug-treatment"
+            # Expected dataset name pattern
+            image_map_dataset = f"reef-imaging/image-map-{dataset_name}"
+            
+            # Check if the specific dataset exists in the gallery
+            try:
+                # List all datasets in the gallery
+                datasets = await artifact_manager_instance._svc.list(parent_id=gallery_id)
+                dataset_exists = any(dataset.get("id") == image_map_dataset for dataset in datasets)
+                
+                if dataset_exists:
+                    print(f"Image map dataset found: {image_map_dataset}")
+                    return {
+                        "success": True, 
+                        "message": f"Image map setup successful for {dataset_name}",
+                        "dataset_id": image_map_dataset
+                    }
+                else:
+                    print(f"Image map dataset not found: {image_map_dataset}")
+                    return {"success": False, "message": f"Image map dataset not found: {image_map_dataset}"}
+            except Exception as e:
+                print(f"Error checking dataset: {e}")
+                return {"success": False, "message": f"Error checking image map dataset: {str(e)}"}
+        except Exception as e:
+            print(f"Error setting up image map: {e}")
+            import traceback
+            print(traceback.format_exc())
+            return {"success": False, "message": f"Error setting up image map: {str(e)}"}
+
+    @app.get("/list-timepoints")
+    async def list_timepoints(dataset_id: str):
+        """
+        Endpoint to list timepoints (subfolders) in an image map dataset.
+        These timepoints are typically folders named by datetime.
+
+        Args:
+            dataset_id (str): The ID of the image map dataset.
+
+        Returns:
+            dict: A dictionary containing timepoints (subfolders) in the dataset.
+        """
+        print(f"Listing timepoints for dataset: {dataset_id}")
+        # Ensure the artifact manager is connected
+        if artifact_manager_instance.server is None:
+            _, artifact_manager_instance._svc = await get_artifact_manager()
+        
+        try:
+            # List all files at the root level of the dataset (should be timepoint folders)
+            files = await artifact_manager_instance._svc.list_files(dataset_id)
+            
+            # Filter for directories only and sort them (they should be in timestamp format)
+            timepoints = [
+                item for item in files 
+                if item.get('type') == 'directory'
+            ]
+            
+            # Sort timepoints chronologically (assuming they're in YYYY-MM-DD_HH-MM-SS format)
+            timepoints.sort(key=lambda x: x.get('name', ''))
+            
+            return {
+                "success": True,
+                "timepoints": timepoints
+            }
+        except Exception as e:
+            print(f"Error listing timepoints: {e}")
+            import traceback
+            print(traceback.format_exc())
+            return {
+                "success": False, 
+                "message": f"Error listing timepoints: {str(e)}",
+                "timepoints": []
+            }
+
+    @app.get("/tile-for-timepoint")
+    async def tile_for_timepoint(dataset_id: str, timepoint: str, channel_name: str = DEFAULT_CHANNEL, z: int = 0, x: int = 0, y: int = 0):
+        """
+        Endpoint to serve tiles for a specific timepoint from an image map dataset.
+
+        Args:
+            dataset_id (str): The ID of the image map dataset.
+            timepoint (str): The timepoint folder name (e.g., "2025-04-10_13-50-7").
+            channel_name (str): The channel name.
+            z (int): The zoom level.
+            x (int): The x coordinate.
+            y (int): The y coordinate.
+
+        Returns:
+            str: Base64 encoded tile image.
+        """
+        print(f"Fetching tile for timepoint: {timepoint}, z={z}, x={x}, y={y}")
+        # Ensure the artifact manager is connected
+        if artifact_manager_instance.server is None:
+            _, artifact_manager_instance._svc = await get_artifact_manager()
+        
+        try:
+            # Construct the full file path including timepoint directory
+            file_path = f"{timepoint}/{channel_name}/scale{z}/{y}.{x}"
+            
+            # Get the file URL
+            get_url = await artifact_manager_instance._svc.get_file(dataset_id, file_path)
+            
+            # Download and process the tile
+            async with httpx.AsyncClient() as client:
+                response = await client.get(get_url)
+                if response.status_code == 200:
+                    # Process the image data
+                    try:
+                        # For OME-Zarr tiles, we might need to decompress them as in TileManager.get_tile_np_data
+                        if tile_manager.compressor:
+                            compressed_data = response.content
+                            decompressed_data = tile_manager.compressor.decode(compressed_data)
+                            tile_data = np.frombuffer(decompressed_data, dtype=np.uint8)
+                            tile_data = tile_data.reshape((tile_manager.tile_size, tile_manager.tile_size))
+                            
+                            # Convert to PNG
+                            image = Image.fromarray(tile_data)
+                            buffer = io.BytesIO()
+                            image.save(buffer, format="PNG")
+                            
+                            # Return as base64
+                            return base64.b64encode(buffer.getvalue()).decode('utf-8')
+                        else:
+                            # If not compressed, return as is (already PNG)
+                            return base64.b64encode(response.content).decode('utf-8')
+                    except Exception as e:
+                        print(f"Error processing tile: {e}")
+                        # Return a blank tile
+                        blank_image = Image.new("L", (tile_manager.tile_size, tile_manager.tile_size), color=0)
+                        buffer = io.BytesIO()
+                        blank_image.save(buffer, format="PNG")
+                        return base64.b64encode(buffer.getvalue()).decode('utf-8')
+                else:
+                    print(f"Failed to fetch tile: {response.status_code}")
+                    blank_image = Image.new("L", (tile_manager.tile_size, tile_manager.tile_size), color=0)
+                    buffer = io.BytesIO()
+                    blank_image.save(buffer, format="PNG")
+                    return base64.b64encode(buffer.getvalue()).decode('utf-8')
+        except Exception as e:
+            print(f"Error fetching tile for timepoint: {e}")
+            import traceback
+            print(traceback.format_exc())
+            blank_image = Image.new("L", (tile_manager.tile_size, tile_manager.tile_size), color=0)
+            buffer = io.BytesIO()
+            blank_image.save(buffer, format="PNG")
+            return base64.b64encode(buffer.getvalue()).decode('utf-8')
 
     async def serve_fastapi(args):
         await app(args["scope"], args["receive"], args["send"])

--- a/frontend/components/DataManagement.jsx
+++ b/frontend/components/DataManagement.jsx
@@ -204,6 +204,9 @@ const DataManagement = ({ appendLog }) => {
       if (data.success) {
         // Store the successful setup in local storage so other components can access it
         localStorage.setItem('imageMapDataset', data.dataset_id);
+        // Also store in session storage to track this was explicitly set in this session
+        sessionStorage.setItem('mapSetupExplicit', 'true');
+        
         setMapSetupStatus({
           isSetup: true,
           message: data.message + '. Go to the main page to view the map.',

--- a/frontend/components/ImageDisplay.jsx
+++ b/frontend/components/ImageDisplay.jsx
@@ -105,10 +105,11 @@ const ImageDisplay = ({ appendLog, segmentService, microscopeControlService, inc
     }
   };
 
-  const loadTimepointMap = (timepoint) => {
+  const loadTimepointMap = (timepoint, channelKey = 0) => {
     if (!timepoint || !mapDatasetId || !map) return;
     
-    appendLog(`Loading map for timepoint: ${timepoint}`);
+    const channelName = channelNames[channelKey] || 'BF_LED_matrix_full';
+    appendLog(`Loading map for timepoint: ${timepoint}, channel: ${channelName}`);
     setSelectedTimepoint(timepoint);
     
     // Remove any existing layers
@@ -119,7 +120,7 @@ const ImageDisplay = ({ appendLog, segmentService, microscopeControlService, inc
     // Create a new tile layer for the selected timepoint
     const newTileLayer = new TileLayer({
       source: new XYZ({
-        url: `tile-for-timepoint?dataset_id=${mapDatasetId}&timepoint=${timepoint}&channel_name=BF_LED_matrix_full&z={z}&x={x}&y={y}`,
+        url: `tile-for-timepoint?dataset_id=${mapDatasetId}&timepoint=${timepoint}&channel_name=${channelName}&z={z}&x={x}&y={y}`,
         crossOrigin: 'anonymous',
         tileSize: 2048,
         maxZoom: 4,
@@ -127,7 +128,7 @@ const ImageDisplay = ({ appendLog, segmentService, microscopeControlService, inc
         tileLoadFunction: function(tile, src) {
           const tileCoord = tile.getTileCoord(); // [z, x, y]
           const transformedZ = 3 - tileCoord[0];
-          const newSrc = `tile-for-timepoint?dataset_id=${mapDatasetId}&timepoint=${timepoint}&channel_name=BF_LED_matrix_full&z=${transformedZ}&x=${tileCoord[1]}&y=${tileCoord[2]}`;
+          const newSrc = `tile-for-timepoint?dataset_id=${mapDatasetId}&timepoint=${timepoint}&channel_name=${channelName}&z=${transformedZ}&x=${tileCoord[1]}&y=${tileCoord[2]}`;
           fetch(newSrc)
             .then(response => response.text())
             .then(data => {
@@ -213,6 +214,9 @@ const ImageDisplay = ({ appendLog, segmentService, microscopeControlService, inc
           vectorLayer={vectorLayer}
           channelNames={channelNames}
           addTileLayer={addTileLayer}
+          isMapViewEnabled={isMapViewEnabled}
+          selectedTimepoint={selectedTimepoint}
+          loadTimepointMap={loadTimepointMap}
         />
         
         {/* Image Map Time Point Selector */}

--- a/frontend/components/MapDisplay.jsx
+++ b/frontend/components/MapDisplay.jsx
@@ -6,7 +6,7 @@ import XYZ from 'ol/source/XYZ';
 import TileLayer from 'ol/layer/Tile';
 import MicroscopeControlPanel from './MicroscopeControlPanel';
 
-const ImageDisplay = ({ appendLog, segmentService, microscopeControlService, incubatorControlService, setCurrentMap }) => {
+const MapDisplay = ({ appendLog, segmentService, microscopeControlService, incubatorControlService, setCurrentMap }) => {
   const [map, setMap] = useState(null);
   const mapRef = useRef(null);
   const effectRan = useRef(false);
@@ -291,7 +291,7 @@ const ImageDisplay = ({ appendLog, segmentService, microscopeControlService, inc
   );
 };
 
-ImageDisplay.propTypes = {
+MapDisplay.propTypes = {
   appendLog: PropTypes.func.isRequired,
   segmentService: PropTypes.object,
   microscopeControlService: PropTypes.object,
@@ -299,4 +299,4 @@ ImageDisplay.propTypes = {
   setCurrentMap: PropTypes.func.isRequired,
 };
 
-export default ImageDisplay;
+export default MapDisplay;

--- a/frontend/components/MapInteractions.jsx
+++ b/frontend/components/MapInteractions.jsx
@@ -6,7 +6,19 @@ import SegmentControls from './SegmentControls';
 import { getSnapshotArray, overlaySegmentationMask } from './Segment';
 import MapButton from './MapButton';
 
-const MapInteractions = ({ segmentService, snapshotImage, map, extent, appendLog, vectorLayer, channelNames, addTileLayer }) => {
+const MapInteractions = ({ 
+  segmentService, 
+  snapshotImage, 
+  map, 
+  extent, 
+  appendLog, 
+  vectorLayer, 
+  channelNames, 
+  addTileLayer,
+  isMapViewEnabled,
+  selectedTimepoint,
+  loadTimepointMap
+}) => {
   const [isFirstClick, setIsFirstClick] = useState(true); // Track if it's the first click for segmentation
   const [isDrawingActive, setIsDrawingActive] = useState(false);
   const [selectedModel, setSelectedModel] = useState('vit_b_lm');
@@ -71,7 +83,13 @@ const MapInteractions = ({ segmentService, snapshotImage, map, extent, appendLog
   };
 
   const handleApplyChannel = () => {
-    addTileLayer(map, selectedChannel);
+    if (isMapViewEnabled && selectedTimepoint) {
+      // Use the loadTimepointMap function for map view
+      loadTimepointMap(selectedTimepoint, selectedChannel);
+    } else {
+      // Use the regular addTileLayer for normal view
+      addTileLayer(map, selectedChannel);
+    }
     setIsChannelSelectorOpen(false);
   };
 
@@ -147,6 +165,15 @@ MapInteractions.propTypes = {
   vectorLayer: PropTypes.object,
   channelNames: PropTypes.object.isRequired,
   addTileLayer: PropTypes.func.isRequired,
+  isMapViewEnabled: PropTypes.bool,
+  selectedTimepoint: PropTypes.string,
+  loadTimepointMap: PropTypes.func
+};
+
+MapInteractions.defaultProps = {
+  isMapViewEnabled: false,
+  selectedTimepoint: null,
+  loadTimepointMap: () => {}
 };
 
 export default MapInteractions;

--- a/frontend/components/MapInteractions.jsx
+++ b/frontend/components/MapInteractions.jsx
@@ -17,13 +17,15 @@ const MapInteractions = ({
   addTileLayer,
   isMapViewEnabled,
   selectedTimepoint,
-  loadTimepointMap
+  loadTimepointMap,
+  currentChannel,
+  setCurrentChannel
 }) => {
   const [isFirstClick, setIsFirstClick] = useState(true); // Track if it's the first click for segmentation
   const [isDrawingActive, setIsDrawingActive] = useState(false);
   const [selectedModel, setSelectedModel] = useState('vit_b_lm');
   const [isChannelSelectorOpen, setIsChannelSelectorOpen] = useState(false);
-  const [selectedChannel, setSelectedChannel] = useState(Object.keys(channelNames)[0]);
+  const [selectedChannel, setSelectedChannel] = useState(currentChannel.toString());
 
   useEffect(() => {
     let clickListener;
@@ -45,6 +47,10 @@ const MapInteractions = ({
       }
     };
   }, [map, isDrawingActive]);
+
+  useEffect(() => {
+    setSelectedChannel(currentChannel.toString());
+  }, [currentChannel]);
 
   const getSegmentedResult = async (pointCoordinates, snapshotArray) => {
     if (isFirstClick) {
@@ -83,14 +89,20 @@ const MapInteractions = ({
   };
 
   const handleApplyChannel = () => {
+    const channelValue = parseInt(selectedChannel);
+    
+    if (setCurrentChannel) {
+      setCurrentChannel(channelValue);
+    }
+    
     if (isMapViewEnabled && selectedTimepoint) {
-      // Use the loadTimepointMap function for map view
-      loadTimepointMap(selectedTimepoint, selectedChannel);
+      loadTimepointMap(selectedTimepoint, channelValue);
     } else {
-      // Use the regular addTileLayer for normal view
-      addTileLayer(map, selectedChannel);
+      addTileLayer(map, channelValue);
     }
     setIsChannelSelectorOpen(false);
+    
+    appendLog(`Channel changed to: ${channelNames[channelValue]}`);
   };
 
   return (
@@ -148,6 +160,11 @@ const MapInteractions = ({
               >
                 Apply
               </button>
+              {isMapViewEnabled && (
+                <div className="mt-2 text-xs text-gray-500">
+                  Current: {channelNames[currentChannel] || 'Unknown'}
+                </div>
+              )}
             </div>
           )}
         </>
@@ -167,13 +184,17 @@ MapInteractions.propTypes = {
   addTileLayer: PropTypes.func.isRequired,
   isMapViewEnabled: PropTypes.bool,
   selectedTimepoint: PropTypes.string,
-  loadTimepointMap: PropTypes.func
+  loadTimepointMap: PropTypes.func,
+  currentChannel: PropTypes.number,
+  setCurrentChannel: PropTypes.func
 };
 
 MapInteractions.defaultProps = {
   isMapViewEnabled: false,
   selectedTimepoint: null,
-  loadTimepointMap: () => {}
+  loadTimepointMap: () => {},
+  currentChannel: 0,
+  setCurrentChannel: () => {}
 };
 
 export default MapInteractions;

--- a/frontend/main.jsx
+++ b/frontend/main.jsx
@@ -34,6 +34,14 @@ const MicroscopeControl = () => {
       }
     }
 
+    // Clear any previous map setup on fresh page load
+    const currentSession = sessionStorage.getItem('mapSetupSession');
+    if (!currentSession) {
+      // This is a fresh login/page load, clear any previous map setup
+      localStorage.removeItem('imageMapDataset');
+      sessionStorage.setItem('mapSetupSession', Date.now().toString());
+    }
+
     checkToken();
   }, []);
 

--- a/frontend/main.jsx
+++ b/frontend/main.jsx
@@ -4,7 +4,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import LogSection from './components/LogSection';
 import LoginPrompt from './components/LoginPrompt';
-import ImageDisplay from './components/ImageDisplay';
+import MapDisplay from './components/MapDisplay';
 import IncubatorControl from './components/IncubatorControl';
 import MicroscopeControlPanel from './components/MicroscopeControlPanel';
 import Sidebar from './components/Sidebar';
@@ -64,7 +64,7 @@ const MicroscopeControl = () => {
     switch (activeTab) {
       case 'main':
         return (
-          <ImageDisplay
+          <MapDisplay
             appendLog={appendLog}
             segmentService={segmentService}
             microscopeControlService={microscopeControlService}


### PR DESCRIPTION
This pull request includes significant updates to both backend and frontend components to support the setup and interaction with image maps for datasets. The most important changes include adding new endpoints for image map setup and interaction, updating the frontend to handle these new functionalities, and removing an obsolete component.

Backend updates:

* [`agent_lens/register_frontend_service.py`](diffhunk://#diff-e671249f7c47b4e27094903bf4de4e98dee6441b9023550d51afc94d847ed869R191-R355): Added new endpoints `/setup-image-map`, `/list-timepoints`, and `/tile-for-timepoint` to support image map setup, listing timepoints, and serving tiles for specific timepoints.

Frontend updates:

* [`frontend/components/DataManagement.jsx`](diffhunk://#diff-55e4c92ba9e17f55deb0febaf37316f3b2ae1a7221429bcb0ce39972b649c2a9R16-R17): Added state and logic to handle the map setup process, including visual feedback for the user and interaction with the new backend endpoints. [[1]](diffhunk://#diff-55e4c92ba9e17f55deb0febaf37316f3b2ae1a7221429bcb0ce39972b649c2a9R16-R17) [[2]](diffhunk://#diff-55e4c92ba9e17f55deb0febaf37316f3b2ae1a7221429bcb0ce39972b649c2a9L188-R239) [[3]](diffhunk://#diff-55e4c92ba9e17f55deb0febaf37316f3b2ae1a7221429bcb0ce39972b649c2a9L205-R262) [[4]](diffhunk://#diff-55e4c92ba9e17f55deb0febaf37316f3b2ae1a7221429bcb0ce39972b649c2a9L226-R287)

Component removal:

* [`frontend/components/ImageDisplay.jsx`](diffhunk://#diff-347be3015ecdf412d772ed3c302bbac61a9dae591c574fc32f4b6f600797d00cL1-L119): Removed the obsolete `ImageDisplay` component, which is no longer needed with the new implementation.