### PR TITLE
update image view

### DIFF
--- a/frontend/components/SampleSelector.jsx
+++ b/frontend/components/SampleSelector.jsx
@@ -26,7 +26,8 @@ const SampleSelector = ({
   // Define the mapping of sample IDs to their data aliases
   const sampleDataAliases = {
     'simulated-sample-1': 'agent-lens/20250506-scan-time-lapse-2025-05-06_17-56-38',
-    'simulated-sample-2': 'agent-lens/20250429-scan-time-lapse-2025-04-29_15-38-36'
+    'simulated-sample-2': 'agent-lens/20250429-scan-time-lapse-2025-04-29_15-38-36',
+    'simulated-sample-3': 'agent-lens/hpa-sample-2025-01-14_15-00-51'
   };
   
   const isRealMicroscopeSelected = selectedMicroscopeId === 'reef-imaging/mirror-microscope-control-squid-1' ||
@@ -201,12 +202,12 @@ const SampleSelector = ({
       setCurrentOperation('loading');
       try {
         addWorkflowMessage("Loading simulated sample...");
-        if (selectedSampleId === 'simulated-sample-1') {
-          await microscopeControlService.set_simulated_sample_data_alias('agent-lens/20250506-scan-time-lapse-2025-05-06_17-56-38');
-          addWorkflowMessage('Loaded simulated sample 1');
-        } else if (selectedSampleId === 'simulated-sample-2') {
-          await microscopeControlService.set_simulated_sample_data_alias('agent-lens/20250429-scan-time-lapse-2025-04-29_15-38-36');
-          addWorkflowMessage('Loaded simulated sample 2');
+        const dataAlias = sampleDataAliases[selectedSampleId];
+        if (dataAlias) {
+          await microscopeControlService.set_simulated_sample_data_alias(dataAlias);
+          addWorkflowMessage(`Loaded ${selectedSampleId}`);
+        } else {
+          throw new Error(`No data alias found for ${selectedSampleId}`);
         }
         setLoadingStatus('Sample loaded!'); // Update status on success
         setIsSampleLoaded(true);
@@ -511,6 +512,14 @@ const SampleSelector = ({
               >
                 <i className="fas fa-flask"></i> 
                 <span>Simulated Sample 2</span>
+              </button>
+              <button
+                className={`sample-option ${selectedSampleId === 'simulated-sample-3' ? 'active' : ''}`}
+                onClick={() => handleSampleSelect('simulated-sample-3')}
+                disabled={currentOperation !== null}
+              >
+                <i className="fas fa-flask"></i> 
+                <span>Simulated Sample 3</span>
               </button>
             </>
           )}

--- a/frontend/components/Sidebar.jsx
+++ b/frontend/components/Sidebar.jsx
@@ -23,7 +23,8 @@ const Sidebar = ({
   const [selectedGalleryId, setSelectedGalleryId] = useState('agent-lens/20250506-scan-time-lapse-gallery');
   const [selectedGalleryName, setSelectedGalleryName] = useState('');
   const [availableGalleries, setAvailableGalleries] = useState([
-    { id: 'agent-lens/20250506-scan-time-lapse-gallery', name: 'Default Time-lapse Gallery' }
+    { id: 'agent-lens/20250506-scan-time-lapse-gallery', name: 'Default Time-lapse Gallery' },
+    { id: 'agent-lens/hpa-sample-gallery', name: 'HPA Sample Gallery' }
   ]);
   const [isSettingUpGalleryMap, setIsSettingUpGalleryMap] = useState(false);
 

--- a/frontend/components/Sidebar.jsx
+++ b/frontend/components/Sidebar.jsx
@@ -90,7 +90,7 @@ const Sidebar = ({
   };
 
   const handleImageViewTabClick = () => {
-    if (activeTab === 'image-view') {
+    if (activeTab === 'image-view' || activeTab === 'image-view-map') {
       const newPanelState = !isImageViewPanelOpen;
       setIsImageViewPanelOpen(newPanelState);
     } else {
@@ -116,6 +116,34 @@ const Sidebar = ({
     window.dispatchEvent(new CustomEvent('gallerySelected', { 
       detail: { galleryId: selectedGalleryId, galleryName: selectedGalleryName } 
     }));
+  };
+
+  const handleGalleryDoubleClick = (galleryId) => {
+    // Step 1: Select the gallery (this updates UI and might trigger async name fetch)
+    setSelectedGalleryId(galleryId);
+
+    // Step 2: Prepare to trigger the data loading for ImageViewBrowser
+    const galleryInfo = availableGalleries.find(g => g.id === galleryId);
+    const nameToDispatch = galleryInfo ? galleryInfo.name : (galleryId.split('/').pop() || galleryId);
+    setSelectedGalleryName(nameToDispatch); // Set name for immediate consistency
+
+    // Step 3: Update localStorage and dispatch the event for ImageViewBrowser.
+    localStorage.setItem('selectedGalleryId', galleryId);
+    localStorage.setItem('selectedGalleryName', nameToDispatch);
+    window.dispatchEvent(new CustomEvent('gallerySelected', {
+      detail: { galleryId: galleryId, galleryName: nameToDispatch }
+    }));
+
+    // Step 4: Ensure the correct tab and panel state
+    if (activeTab === 'image-view-map') {
+      onTabChange('image-view'); // Switch from map view to browser view
+    } else if (activeTab !== 'image-view') {
+      onTabChange('image-view'); // Switch to image view tab if not already on it or map view
+    }
+
+    if (!isImageViewPanelOpen) {
+      setIsImageViewPanelOpen(true); // Open the panel if it's closed
+    }
   };
 
   const handleViewGalleryImageData = async () => {
@@ -150,11 +178,6 @@ const Sidebar = ({
   const handleCloseMapView = () => {
     // Close the map view and return to image view
     onTabChange('image-view');
-  };
-
-  const handleGallerySelect = async (galleryId) => {
-    setSelectedGalleryId(galleryId);
-    // Gallery name will be fetched by the useEffect
   };
 
   const handleAddGallery = () => {
@@ -303,10 +326,11 @@ const Sidebar = ({
                 <div 
                   key={gallery.id}
                   className={`gallery-option ${selectedGalleryId === gallery.id ? 'active' : ''}`}
+                  onDoubleClick={() => handleGalleryDoubleClick(gallery.id)} // Double click handler
                 >
                   <button
                     className="gallery-select-btn"
-                    onClick={() => handleGallerySelect(gallery.id)}
+                    // onClick is removed to prevent single-click selection changing highlight
                   >
                     <i className="fas fa-folder"></i>
                     <span>{gallery.name}</span>


### PR DESCRIPTION
### Enhancements to `SampleSelector`:

* Added support for a new simulated sample (`simulated-sample-3`) by updating the `sampleDataAliases` mapping and creating a corresponding button for selection. [[1]](diffhunk://#diff-1cd3fc15145e969e4eae4467e9b1d88f48e21b8576f373175b57249145897ff7L29-R30) [[2]](diffhunk://#diff-1cd3fc15145e969e4eae4467e9b1d88f48e21b8576f373175b57249145897ff7R516-R523)
* Refactored the sample loading logic to dynamically fetch data aliases from `sampleDataAliases`, reducing redundancy and improving error handling for unsupported sample IDs.

### Enhancements to `Sidebar`:

* Added a new gallery (`HPA Sample Gallery`) to the list of available galleries, improving gallery options for users.
* Introduced a `handleGalleryDoubleClick` function to enable gallery selection via double-click, which updates the UI, synchronizes with `localStorage`, dispatches an event, and ensures the correct tab/panel state. This replaces the previous single-click selection behavior. [[1]](diffhunk://#diff-024ee713a8a6394858052d8d8e682bdaa22b6475c5cf48b8039e25d6c5d194a9R121-R148) [[2]](diffhunk://#diff-024ee713a8a6394858052d8d8e682bdaa22b6475c5cf48b8039e25d6c5d194a9R329-R333)
* Improved tab-switching logic by allowing seamless transitions between the map view and image view when interacting with galleries.