### PR TITLE
Improve WebRTC

### DIFF
--- a/frontend/components/MicroscopeControlPanel.jsx
+++ b/frontend/components/MicroscopeControlPanel.jsx
@@ -719,14 +719,14 @@ const MicroscopeControlPanel = ({
                     onClick={() => moveMicroscope(axis, -1)}
                     disabled={!microscopeControlService || currentOperation !== null}
                   >
-                    <i className={`fas fa-arrow-${axis === 'x' ? 'left' : 'down'} mr-1`}></i> {axis.toUpperCase()}-
+                    <i className={`fas fa-arrow-${axis === 'x' ? 'left' : axis === 'y' ? 'up' : 'down'} mr-1`}></i> {axis.toUpperCase()}-
                   </button>
                   <button
                     className="half-button bg-blue-500 text-white hover:bg-blue-600 w-1/2 p-1 rounded text-xs disabled:opacity-75 disabled:cursor-not-allowed"
                     onClick={() => moveMicroscope(axis, 1)}
                     disabled={!microscopeControlService || currentOperation !== null}
                   >
-                    {axis.toUpperCase()}+ <i className={`fas fa-arrow-${axis === 'x' ? 'right' : 'up'} ml-1`}></i>
+                    {axis.toUpperCase()}+ <i className={`fas fa-arrow-${axis === 'x' ? 'right' : axis === 'y' ? 'down' : 'up'} ml-1`}></i>
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
### WebRTC Stream Handling Improvements:
* Added a memoized function `memoizedStopWebRtcStream` using `useCallback` to streamline stopping the WebRTC stream. This replaces the previous `stopWebRtcStream` function. (`[[1]](diffhunk://#diff-97d9a613971a8ff0e9880f48f802dc05c2046e01ef3f149adbe0c3f804fa394fR83-R101)`, `[[2]](diffhunk://#diff-97d9a613971a8ff0e9880f48f802dc05c2046e01ef3f149adbe0c3f804fa394fL374-R415)`)
* Updated all references to `stopWebRtcStream` to use `memoizedStopWebRtcStream`, including cleanup effects, toggling streams, and snapping images. (`[[1]](diffhunk://#diff-97d9a613971a8ff0e9880f48f802dc05c2046e01ef3f149adbe0c3f804fa394fL347-R366)`, `[[2]](diffhunk://#diff-97d9a613971a8ff0e9880f48f802dc05c2046e01ef3f149adbe0c3f804fa394fL374-R415)`, `[[3]](diffhunk://#diff-97d9a613971a8ff0e9880f48f802dc05c2046e01ef3f149adbe0c3f804fa394fL480-R481)`)

### UI Fixes:
* Corrected the logic for determining arrow icons in microscope movement controls, ensuring the correct direction is displayed for each axis. (`[frontend/components/MicroscopeControlPanel.jsxL722-R730](diffhunk://#diff-97d9a613971a8ff0e9880f48f802dc05c2046e01ef3f149adbe0c3f804fa394fL722-R730)`)