### PR TITLE
Well seperated canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Built for research laboratories, Agent-Lens combines modern web technologies wit
 - **High-resolution Display**: OpenLayers-based pan/zoom interface
 - **Annotation Tools**: Points, polygons, and custom markers
 - **Data Management**: Zarr-based efficient storage and retrieval
+- **Interactive Image Map**: Pan/zoomable stage map with well plate overlay, scan area selection, and multi-well support
 
 ### 🏭 **Hardware Integration**
 - **Robotic Automation**: Automated sample handling and transfer
@@ -210,6 +211,17 @@ agent-lens/
 - Real-time hardware control with safety mechanisms
 - Multi-axis positioning and automated movements
 - Channel management and illumination control
+
+### **Microscope Image Map**
+- **Interactive Stage Map**: Visualize the entire microscope stage with pan and zoom controls.
+- **Well Plate Overlay**: See 96, 48, or 24-well plate layouts directly on the map.
+- **Scan Area Selection**: Click and drag to select scan regions within wells, with visual feedback.
+- **Multi-Well Support**: Select multiple wells for batch scanning or time-lapse imaging.
+- **Live Video Integration**: See the current field of view (FOV) and live video position on the map.
+- **Scan Results Overlay**: View stitched scan results as image tiles, with channel selection and layer controls.
+- **Experiment Management**: Organize scan data by experiment, with per-well canvases and metadata.
+
+The image map is powered by the `MicroscopeMapDisplay` React component, integrated into the main control panel. It provides a seamless experience for both real and simulated microscopes, supporting advanced workflows like multi-well scanning and experiment-based data management.
 
 ### **AI Segmentation Engine**
 - Multiple model support (SAM, custom models)

--- a/frontend/components/MicroscopeMapDisplay.css
+++ b/frontend/components/MicroscopeMapDisplay.css
@@ -303,3 +303,83 @@ input[type="checkbox"]:disabled + span {
     box-shadow: 0 2px 12px rgba(251, 146, 60, 0.6);
   }
 }
+
+/* Multi-well selection grid for Scan Configuration panel */
+.scan-well-plate-grid-container {
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  user-select: none;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.scan-well-plate-grid {
+  display: grid;
+  grid-template-columns: auto repeat(12, 1fr);
+  gap: 1px;
+  border: 1px solid #374151;
+  padding: 2px;
+  background-color: #23272f;
+  width: 100%;
+  max-width: 260px; /* was 340px */
+  border-radius: 0.5rem;
+}
+
+.scan-grid-row {
+  display: contents;
+}
+
+.scan-grid-col-labels {
+  display: contents;
+}
+
+.scan-grid-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  font-size: 0.65rem;
+  font-weight: bold;
+  background-color: #374151;
+  color: #cbd5e1;
+  min-width: 14px;
+  text-align: center;
+  border-radius: 0.25rem;
+}
+
+.scan-grid-cell {
+  padding: 3px;
+  border: 1px solid #374151;
+  background-color: #23272f;
+  text-align: center;
+  cursor: pointer;
+  font-size: 0.6rem;
+  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+  min-width: 14px;
+  min-height: 14px;
+  border-radius: 0.25rem;
+  color: #cbd5e1;
+}
+
+.scan-grid-cell:hover {
+  background-color: #334155;
+}
+
+.scan-grid-cell.selected {
+  background-color: #2563eb;
+  color: #fff;
+  border-color: #1d4ed8;
+}
+
+.scan-grid-cell:disabled {
+  background-color: #1e293b;
+  cursor: not-allowed;
+  color: #64748b;
+}
+
+/* Ensure the first cell in the column labels row (top-left empty cell) is styled like other labels */
+.scan-well-plate-grid > .scan-grid-col-labels > div:first-child {
+  background-color: #374151;
+  border: none;
+}

--- a/frontend/components/MicroscopeMapDisplay.jsx
+++ b/frontend/components/MicroscopeMapDisplay.jsx
@@ -3550,21 +3550,21 @@ const MicroscopeMapDisplay = ({
                   
                   if (appendLog) appendLog(`Starting quick scan: ${quickScanParameters.wellplate_type}-well plate, ${quickScanParameters.n_stripes} stripes × ${quickScanParameters.stripe_width_mm}mm, scan velocity ${quickScanParameters.velocity_scan_mm_per_s}mm/s, ${quickScanParameters.fps_target}fps`);
                   
-                      const result = await microscopeControlService.quick_scan_with_stitching({
-                      wellplate_type: quickScanParameters.wellplate_type,
-                      exposure_time: quickScanParameters.exposure_time,
-                      intensity: quickScanParameters.intensity,
-                      fps_target: quickScanParameters.fps_target,
-                      action_ID: 'quick_scan_' + Date.now(),
-                      n_stripes: quickScanParameters.n_stripes,
-                      stripe_width_mm: quickScanParameters.stripe_width_mm,
-                      dy_mm: quickScanParameters.dy_mm,
-                      velocity_scan_mm_per_s: quickScanParameters.velocity_scan_mm_per_s,
-                      do_contrast_autofocus: quickScanParameters.do_contrast_autofocus,
-                      do_reflection_af: quickScanParameters.do_reflection_af,
-                      experiment_name: activeExperiment, // Use active experiment
-                      well_padding_mm: wellPaddingMm // Add well padding parameter
-                    });
+                      const result = await microscopeControlService.quick_scan_with_stitching(
+                      quickScanParameters.wellplate_type,
+                      quickScanParameters.exposure_time,
+                      quickScanParameters.intensity,
+                      quickScanParameters.fps_target,
+                      'quick_scan_' + Date.now(),
+                      quickScanParameters.n_stripes,
+                      quickScanParameters.stripe_width_mm,
+                      quickScanParameters.dy_mm,
+                      quickScanParameters.velocity_scan_mm_per_s,
+                      quickScanParameters.do_contrast_autofocus,
+                      quickScanParameters.do_reflection_af,
+                      activeExperiment, // Use active experiment
+                      wellPaddingMm // Add well padding parameter
+                    );
                   
                   if (result.success) {
                     if (showNotification) showNotification('Quick scan completed successfully', 'success');

--- a/frontend/components/MicroscopeMapDisplay.jsx
+++ b/frontend/components/MicroscopeMapDisplay.jsx
@@ -179,7 +179,7 @@ const MicroscopeMapDisplay = ({
   // Well selection state for scanning
   const [selectedWells, setSelectedWells] = useState(['A1']); // Default to A1
   const [wellPlateType, setWellPlateType] = useState('96'); // Default to 96-well
-  const [wellPaddingMm, setWellPaddingMm] = useState(2.0); // Default padding
+  const [wellPaddingMm, setWellPaddingMm] = useState(1.0); // Default padding
 
   // Helper function to get well plate configuration
   const getWellPlateConfig = useCallback(() => {
@@ -2520,9 +2520,7 @@ const MicroscopeMapDisplay = ({
                   </select>
                 </div>
 
-
-
-                 {/* Well Padding Control */}
+                 {/* Well Padding Control
                  <div className="flex items-center space-x-1">
                    <label className="text-white text-xs">Padding:</label>
                    <input
@@ -2537,7 +2535,7 @@ const MicroscopeMapDisplay = ({
                      title="Well padding in mm"
                    />
                    <span className="text-gray-400 text-xs">mm</span>
-                 </div>
+                 </div> */}
                 
                 <button
                 onClick={() => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hypha_rpc==0.20.65
+hypha_rpc==0.20.66
 numpy==2.1.3
 pillow==11.0.0
 httpx==0.28.1


### PR DESCRIPTION
### New grid layout and styling:

This new feature adds an interactive, grid-based multi-well selection UI to the Scan Configuration panel.

Users can now select multiple wells on a virtual well plate by clicking or dragging across the grid—each selection adds to the current set, allowing for flexible, non-contiguous region selection. A "Refresh" button lets users quickly clear all selections. When a scan is started, all selected wells are included, and the scan preview overlays are shown for each well on the map, making it easy to plan and visualize multi-well scans in one operation.
